### PR TITLE
    Revert "bpf: Remove ICMPv6 NS Responder on bpf_host"

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -149,8 +149,7 @@ handle_ipv6(struct __ctx_buff *ctx, __u32 secctx __maybe_unused,
 #endif /* ENABLE_HOST_FIREWALL */
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
-	int __maybe_unused ret;
-	int hdrlen;
+	int ret, hdrlen;
 	__u8 nexthdr;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip6))
@@ -161,7 +160,6 @@ handle_ipv6(struct __ctx_buff *ctx, __u32 secctx __maybe_unused,
 	if (hdrlen < 0)
 		return hdrlen;
 
-#ifdef ENABLE_HOST_FIREWALL
 	if (likely(nexthdr == IPPROTO_ICMPV6)) {
 		ret = icmp6_host_handle(ctx);
 		if (ret == SKIP_HOST_FIREWALL)
@@ -169,7 +167,6 @@ handle_ipv6(struct __ctx_buff *ctx, __u32 secctx __maybe_unused,
 		if (IS_ERR(ret))
 			return ret;
 	}
-#endif /* ENABLE_HOST_FIREWALL */
 
 #ifdef ENABLE_NODEPORT
 	if (!from_host) {
@@ -214,8 +211,10 @@ handle_ipv6(struct __ctx_buff *ctx, __u32 secctx __maybe_unused,
 		if (map_update_elem(&CT_TAIL_CALL_BUFFER6, &zero, &ct_buffer, 0) < 0)
 			return DROP_INVALID_TC_BUFFER;
 	}
+#endif /* ENABLE_HOST_FIREWALL */
 
 skip_host_firewall:
+#ifdef ENABLE_HOST_FIREWALL
 	ctx_store_meta(ctx, CB_FROM_HOST,
 		       (need_hostfw ? FROM_HOST_FLAG_NEED_HOSTFW : 0) |
 		       (is_host_id ? FROM_HOST_FLAG_HOST_ID : 0));

--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -397,7 +397,10 @@ icmp6_host_handle(struct __ctx_buff *ctx __maybe_unused)
 	__u8 type __maybe_unused;
 
 	type = icmp6_load_type(ctx, ETH_HLEN);
+	if (type == ICMP6_NS_MSG_TYPE)
+		return icmp6_handle_ns(ctx, ETH_HLEN, METRIC_INGRESS);
 
+#ifdef ENABLE_HOST_FIREWALL
 	/* When the host firewall is enabled, we drop and allow ICMPv6 messages
 	 * according to RFC4890, except for echo request and reply messages which
 	 * are handled by host policies and can be dropped.
@@ -417,7 +420,7 @@ icmp6_host_handle(struct __ctx_buff *ctx __maybe_unused)
 	 * |      ICMPv6-mult-list-done      |   CTX_ACT_OK    |  132 |
 	 * |      ICMPv6-router-solici       |   CTX_ACT_OK    |  133 |
 	 * |      ICMPv6-router-advert       |   CTX_ACT_OK    |  134 |
-	 * |     ICMPv6-neighbor-solicit     |   CTX_ACT_OK    |  135 |
+	 * |     ICMPv6-neighbor-solicit     | icmp6_handle_ns |  135 |
 	 * |      ICMPv6-neighbor-advert     |   CTX_ACT_OK    |  136 |
 	 * |     ICMPv6-redirect-message     |  CTX_ACT_DROP   |  137 |
 	 * |      ICMPv6-router-renumber     |   CTX_ACT_OK    |  138 |
@@ -445,9 +448,6 @@ icmp6_host_handle(struct __ctx_buff *ctx __maybe_unused)
 	 * |       ICMPv6-unassigned         |  CTX_ACT_DROP   |      |
 	 */
 
-	if (type == ICMP6_NS_MSG_TYPE)
-		return CTX_ACT_OK;
-
 	if (type == ICMP6_ECHO_REQUEST_MSG_TYPE || type == ICMP6_ECHO_REPLY_MSG_TYPE)
 		/* Decision is deferred to the host policies. */
 		return CTX_ACT_OK;
@@ -459,6 +459,9 @@ icmp6_host_handle(struct __ctx_buff *ctx __maybe_unused)
 		(ICMP6_MULT_RA_MSG_TYPE <= type && type <= ICMP6_MULT_RT_MSG_TYPE))
 		return SKIP_HOST_FIREWALL;
 	return DROP_FORBIDDEN_ICMP6;
+#else
+	return CTX_ACT_OK;
+#endif /* ENABLE_HOST_FIREWALL */
 }
 
 #endif


### PR DESCRIPTION
This reverts commit 658071414ca4606e537bc4bbb37dcae5e18cd7dc.
    Underlay interface should response for ND request for IPv6 with
    native routing and without any additional routing infromation.
