### PR TITLE
Accept ipamOption.IPAMDelegatedPlugin if bgpControlPlane.enabled

### DIFF
--- a/pkg/bgpv1/agent/nodespecer.go
+++ b/pkg/bgpv1/agent/nodespecer.go
@@ -45,7 +45,7 @@ func NewNodeSpecer(params localNodeStoreSpecerParams) (nodeSpecer, error) {
 	}
 
 	switch params.Config.IPAM {
-	case ipamOption.IPAMClusterPoolV2, ipamOption.IPAMClusterPool:
+	case ipamOption.IPAMClusterPoolV2, ipamOption.IPAMClusterPool, ipamOption.IPAMDelegatedPlugin:
 		cns := &ciliumNodeSpecer{
 			nodeResource: params.CiliumNodeResource,
 			signaler:     params.Signaler,


### PR DESCRIPTION
those 2 options are incompatible in 1.14.6:
``
pam:
  mode: delegated-plugin
bgpControlPlane:
  enabled: true
``
trying to overcome this issue without backporting: https://github.com/cilium/cilium/pull/27285