### PR TITLE
Allow ipip traffic for ipv4 ldrie dynamic balancers

### DIFF
--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -553,6 +553,10 @@ ct_extract_ports6(struct __ctx_buff *ctx, int off, struct ipv6_ct_tuple *tuple)
 			return DROP_CT_INVALID_HDR;
 
 		break;
+	case IPPROTO_IPIP:
+		if (l4_load_ports(ctx, off+sizeof(struct iphdr), &tuple->dport) < 0)
+			return DROP_CT_INVALID_HDR;
+        break;
 	default:
 		/* Can't handle extension headers yet */
 		return DROP_CT_UNKNOWN_PROTO;

--- a/nebius/patches/allow_ipip_traffic.diff
+++ b/nebius/patches/allow_ipip_traffic.diff
@@ -1,0 +1,15 @@
+diff --git a/bpf/lib/conntrack.h b/bpf/lib/conntrack.h
+index 4fb2f84c1f..111d853636 100644
+--- a/bpf/lib/conntrack.h
++++ b/bpf/lib/conntrack.h
+@@ -553,6 +553,10 @@ ct_extract_ports6(struct __ctx_buff *ctx, int off, struct ipv6_ct_tuple *tuple)
+ 			return DROP_CT_INVALID_HDR;
+ 
+ 		break;
++	case IPPROTO_IPIP:
++		if (l4_load_ports(ctx, off+sizeof(struct iphdr), &tuple->dport) < 0)
++			return DROP_CT_INVALID_HDR;
++        break;
+ 	default:
+ 		/* Can't handle extension headers yet */
+ 		return DROP_CT_UNKNOWN_PROTO;


### PR DESCRIPTION
Add patch for IK8SNET-497

To apply `git apply nebius/patches/allow_ipip_traffic.diff`